### PR TITLE
Feature/resource proxy rewrite

### DIFF
--- a/src/Maps4News.js
+++ b/src/Maps4News.js
@@ -88,7 +88,7 @@ export default class Maps4News {
     this.auth = auth;
     this.host = host;
 
-    const bool = (str) => str.toLowerCase() === 'true';
+    const bool = str => str.toLowerCase() === 'true';
 
     /**
      * Defaults for common parameters. These are populated during the build process using the `.env` file.

--- a/src/Maps4News.js
+++ b/src/Maps4News.js
@@ -77,7 +77,6 @@ import {makeRequest} from './utils/requests';
 
 /**
  * Base API class
- * @todo Add setting to disable console.warn
  */
 export default class Maps4News {
   /**

--- a/src/PaginatedResourceListing.js
+++ b/src/PaginatedResourceListing.js
@@ -295,11 +295,10 @@ export default class PaginatedResourceListing {
 
   /**
    * Wraps {@link PaginatedResourceWrapper} around the page
-   * @param {Number} cacheTime - Amount of seconds to store a value in cache
    * @param {Boolean} shareCache - Share cache across instances
    * @returns {PaginatedResourceWrapper} - Wrapped resource listing
    */
-  wrap(cacheTime = this.api.defaults.cacheSeconds, shareCache = this.api.defaults._shareCache) {
-    return new PaginatedResourceWrapper(this, this.api, cacheTime, shareCache);
+  wrap(shareCache = this.api.defaults._shareCache) {
+    return new PaginatedResourceWrapper(this, this.api, shareCache);
   }
 }

--- a/src/PaginatedResourceWrapper.js
+++ b/src/PaginatedResourceWrapper.js
@@ -43,14 +43,12 @@ export default class PaginatedResourceWrapper {
    *
    * @param {PaginatedResourceListing} listing - Listing result
    * @param {Maps4News} api - Instance of the api
-   * @param {Number} cacheTime - Amount of seconds to store a value in cache
    * @param {Boolean} shareCache - Share cache across instances
    */
-  constructor(listing, api = listing.api, cacheTime = api.defaults.cacheSeconds, shareCache = api.defaults.shareCache) {
+  constructor(listing, api = listing.api, shareCache = api.defaults.shareCache) {
 
     // Fields
     this._api = api;
-    this.cacheTime = cacheTime;
     this._shareCache = shareCache;
     this._currentPage = 1;
     this._context = [];
@@ -62,7 +60,7 @@ export default class PaginatedResourceWrapper {
     this.data = [];
 
     // Internal
-    this._localCache = new ResourceCache(api, cacheTime);
+    this._localCache = new ResourceCache(api, this.api.defaults.cacheSeconds);
     this._inflight = [];
     this._last = listing;
     this._waiting = false;

--- a/src/PaginatedResourceWrapper.js
+++ b/src/PaginatedResourceWrapper.js
@@ -289,14 +289,16 @@ export default class PaginatedResourceWrapper {
   /**
    * Register an event handler for the given type.
    *
-   * @param {string} type Type of event to listen for, or `"*"` for all events.
-   * @param {function(event: any): void} handler Function to call in response to the given event.
+   * @param {string} type - Type of event to listen for, or `"*"` for all events.
+   * @param {function(eventType: string, event: any): void|function(event: any): void} handler - Function to call in response to the given event.
    * @returns {void}
    */
   on(type, handler) {
-    this.cache.emitter.on(type, e => {
-      if (e.resourceUrl === this.route) {
-        handler(e);
+    this.cache.emitter.on(type, (t, e) => {
+      if (type === '*' && e.resourceUrl === this.route) {
+        handler(t, e);
+      } else if (type !== '*' && t.resourceUrl === this.route) {
+        handler(t);
       }
     });
   }
@@ -304,8 +306,8 @@ export default class PaginatedResourceWrapper {
   /**
    * Function to call in response to the given event
    *
-   * @param {string} type Type of event to unregister `handler` from, or `"*"`
-   * @param {function(event: any): void} handler Handler function to remove.
+   * @param {string} type - Type of event to unregister `handler` from, or `"*"`
+   * @param {function(event: any): void} handler - Handler function to remove.
    * @returns {void}
    */
   off(type, handler) {

--- a/src/ResourceCache.js
+++ b/src/ResourceCache.js
@@ -72,7 +72,7 @@ export default class ResourceCache {
       throw new TypeError('Missing or invalid row.id for page.data. Data rows must to contain a numeric "id" field.');
     }
 
-    const validThrough = this._timestamp() + this.cacheTime;
+    const validThrough = this._timestamp + this.cacheTime;
     const cacheId = Uuid.uuid4();
     const data = {
       page, validThrough, diff,
@@ -137,10 +137,10 @@ export default class ResourceCache {
       // Remove old data from the cache and stop old timeouts
       Object.keys(storage).forEach(key => {
         storage[key]
-          .filter(row => row.validThrough < this._timestamp())
+          .filter(row => row.validThrough < this._timestamp)
           .forEach(row => clearTimeout(row.timeout));
 
-        storage[key] = storage[key].filter(row => row.validThrough >= this._timestamp());
+        storage[key] = storage[key].filter(row => row.validThrough >= this._timestamp);
       });
 
       const junk = Object.keys(storage).filter(key => storage[key].length === 0);
@@ -364,7 +364,7 @@ export default class ResourceCache {
    * @returns {number} - timestamp
    * @private
    */
-  _timestamp() {
+  get _timestamp() {
     return Math.floor(Date.now() / 1000);
   }
 }

--- a/src/ResourceCache.js
+++ b/src/ResourceCache.js
@@ -39,9 +39,10 @@ import Uuid from './utils/uuid';
  * @todo Add periodic data refreshing while idle, most likely implemented in cache
  */
 export default class ResourceCache {
-  constructor(api, cacheTime = api.defaults.cacheSeconds) {
+  constructor(api, cacheTime = api.defaults.cacheSeconds, dereference = api.defaults.dereferenceCache) {
     this._api = api;
     this.cacheTime = cacheTime;
+    this.dereference = dereference;
     this.emitter = mitt();
 
     this._storage = {};
@@ -196,12 +197,11 @@ export default class ResourceCache {
    * Resolve cache and return indexed data
    * @param {String} resourceUrl - Resource url
    * @param {String} cacheToken - Cache token
-   * @param {Boolean} dereference - Dereference output data by cloning the instances before returning them.
    * @see {@link PaginatedResourceListing#cacheToken}
    * @returns {Array} - Indexed relevant data
    * @todo add page numbers or range as optional parameter
    */
-  resolve(resourceUrl, cacheToken = '', dereference = this._api.defaults.dereferenceCache) {
+  resolve(resourceUrl, cacheToken = '') {
     cacheToken = cacheToken.toLowerCase();
 
     const data = this.collectPages(resourceUrl, cacheToken);
@@ -254,7 +254,7 @@ export default class ResourceCache {
       badKeys.forEach(key => delete out[key]);
     }
 
-    if (dereference) {
+    if (this.dereference) {
       return out.map(x => x.clone());
     }
 

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -152,7 +152,7 @@ export default class SimpleResourceProxy {
    *   scale_min: ['>:1', '<:10'],
    * };
    *
-   * api.layers.list({perPage: 10, search});
+   * api.layers.listandWrap({perPage: 10, search});
    */
   listAndWrap(params) {
     const resolver = this._buildResolver(params);
@@ -177,6 +177,10 @@ export default class SimpleResourceProxy {
     return new PaginatedResourceListing(this._api, url, this.Target, params.search, params.page, params.perPage);
   }
 
+  /**
+   * Get the defaults parameters.
+   * @returns {{page: number, perPage: number, shareCache: boolean, search: {}}} - Defaults
+   */
   get defaultParams() {
     const defaults = this.api.defaults;
 

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -102,81 +102,6 @@ export default class SimpleResourceProxy {
   }
 
   /**
-   * Lists target resource
-   * @param {Object<String, String|Array<String>>} query - Query
-   * @param {Number} page - The page to be requested
-   * @param {Number} perPage - Amount of items per page. This is silently capped by the API
-   * @returns {Promise} - Resolves with {@link PaginatedResourceListing} instance and rejects with {@link ApiError}
-   *
-   * @example
-   * // Find layers with a name that starts with "test" and a scale_min between 1 and 10
-   * // See Api documentation for search query syntax
-   * var query = {
-   *   name: '^:test',
-   *   scale_min: ['>:1', '<:10'],
-   * }
-   *
-   * api.layers.search(query).then(console.dir);
-   * @todo move page, perPage, etc. to an object and add other options
-   */
-  search(query, page = 1, perPage = this.api.defaults.perPage) {
-    const url = this._baseUrl;
-    const resolver = new PaginatedResourceListing(this._api, url, this.Target, query);
-
-    return resolver.getPage(page, perPage);
-  }
-
-  /**
-   * Lists target resource
-   * @param {Number} page - The page to be requested
-   * @param {Number|undefined} perPage - Amount of items per page. This is silently capped by the API
-   * @returns {Promise} - Resolves with {@link PaginatedResourceListing} instance and rejects with {@link ApiError}
-   */
-  list(page = 1, perPage = this.api.defaults.perPage) {
-    return this.search({}, page, perPage);
-  }
-
-  /**
-   * Lists target resource
-   * @param {Number} page - The page to be requested
-   * @param {Number} perPage - Amount of items per page. This is silently capped by the API
-   * @param {Boolean} shareCache - Share cache across instances
-   * @returns {PaginatedResourceWrapper} - Resolves with {@link PaginatedResourceListing} instance and rejects with {@link ApiError}
-   *
-   */
-  listAndWrap(page = 1, perPage = this.api.defaults.perPage, shareCache = this.api.defaults._shareCache) {
-    return this.searchAndWrap({}, page, perPage, shareCache);
-  }
-
-  /**
-   * Lists target resource
-   * @param {Object<String, String|Array<String>>} query - Query
-   * @param {Number} page - The page to be requested
-   * @param {Number} perPage - Amount of items per page. This is silently capped by the API
-   * @param {Boolean} shareCache - Share cache across instances
-   * @returns {PaginatedResourceWrapper} - Wrapped {@link PaginatedResourceListing} instance
-   *
-   * @example
-   * // Find layers with a name that starts with "test" and a scale_min between 1 and 10
-   * // See Api documentation for search query syntax
-   * var query = {
-   *   name: '^:test',
-   *   scale_min: ['>:1', '<:10'],
-   * }
-   *
-   * api.layers.searchAndWrap(query)
-   */
-  searchAndWrap(query, page = 1, perPage = this.api.defaults.perPage, shareCache = this.api.defaults._shareCache) {
-    const url = this._baseUrl;
-    const resolver = new PaginatedResourceListing(this._api, url, this.Target, query, page, perPage);
-    const wrapped = resolver.wrap(shareCache);
-
-    wrapped.get(page);
-
-    return wrapped;
-  }
-
-  /**
    * Build a new isntance of the target
    * @param {Object<String, *>} data - Data for the object to be populated with
    * @returns {ResourceBase} - Resource with target data
@@ -205,7 +130,7 @@ export default class SimpleResourceProxy {
    *
    * api.layers.list({perPage: 10, search});
    */
-  newList(params) {
+  list(params) {
     Object.assign(params, this.defaultParams);
     return this._buildResolver(params).getPage(params.page);
   }
@@ -228,7 +153,7 @@ export default class SimpleResourceProxy {
    *
    * api.layers.list({perPage: 10, search});
    */
-  newListAndWrap(params) {
+  listAndWrap(params) {
     Object.assign(params, this.defaultParams);
 
     const wrapped = this._buildResolver(params).wrap(params.page);

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -101,7 +101,7 @@ export default class SimpleResourceProxy {
   }
 
   /**
-   * Build a new isntance of the target
+   * Build a new instance of the target
    * @param {Object<String, *>} data - Data for the object to be populated with
    * @returns {ResourceBase} - Resource with target data
    */
@@ -114,7 +114,7 @@ export default class SimpleResourceProxy {
 
   /**
    * List target resource
-   * @param {Number|Object} [params] - ParametersThe page to be requested
+   * @param {Number|Object} [params] - Parameters or the page number to be requested
    * @param {Number} [params.page=1] - The page to be requested
    * @param {Number} [params.perPage=this.api.defaults.perPage] - Amount of items per page. This is silently capped by the API
    * @param {?Object<String, String|Array<String>>} [params.search] - Search parameters
@@ -137,7 +137,7 @@ export default class SimpleResourceProxy {
 
   /**
    * List target resource
-   * @param {Number|Object} [params] - ParametersThe page to be requested
+   * @param {Number|Object} [params] - Parameters or the page to be requested
    * @param {Number} [params.page=1] - The page to be requested
    * @param {Number} [params.perPage=this.api.defaults.perPage] - Amount of items per page. This is silently capped by the API
    * @param {Boolean} [params.shareCache=this.api.defaults.shareCache] - Share cache across instances

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -171,7 +171,7 @@ export default class SimpleResourceProxy {
     }
 
     if (paramType === 'number') {
-      return this.list({page: params});
+      return this._buildResolver({page: params});
     }
 
     return new PaginatedResourceListing(this._api, url, this.Target, params.search, params.page, params.perPage);

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -131,8 +131,9 @@ export default class SimpleResourceProxy {
    * api.layers.list({perPage: 10, search});
    */
   list(params) {
-    Object.assign(params, this.defaultParams);
-    return this._buildResolver(params).getPage(params.page);
+    const resolver = this._buildResolver(params);
+
+    return resolver.getPage(resolver.page);
   }
 
   /**
@@ -154,11 +155,10 @@ export default class SimpleResourceProxy {
    * api.layers.list({perPage: 10, search});
    */
   listAndWrap(params) {
-    Object.assign(params, this.defaultParams);
+    const resolver = this._buildResolver(params);
+    const wrapped = resolver.wrap(resolver.page);
 
-    const wrapped = this._buildResolver(params).wrap(params.page);
-
-    wrapped.get(params.page);
+    wrapped.get(resolver.page);
     return wrapped;
   }
 
@@ -171,7 +171,7 @@ export default class SimpleResourceProxy {
     }
 
     if (paramType === 'number') {
-      return this.newList({page: params});
+      return this.list({page: params});
     }
 
     return new PaginatedResourceListing(this._api, url, this.Target, params.search, params.page, params.perPage);

--- a/src/SimpleResourceProxy.js
+++ b/src/SimpleResourceProxy.js
@@ -38,7 +38,6 @@ import {isParentOf} from './utils/reflection';
  * Proxy for accessing resource. This will make sure that they
  * are properly wrapped before the promise resolves.
  * @protected
- * @todo remove ::search* in favor of an object containing function parameters
  */
 export default class SimpleResourceProxy {
   /**
@@ -115,7 +114,7 @@ export default class SimpleResourceProxy {
 
   /**
    * List target resource
-   * @param {Number|Object} params - ParametersThe page to be requested
+   * @param {Number|Object} [params] - ParametersThe page to be requested
    * @param {Number} [params.page=1] - The page to be requested
    * @param {Number} [params.perPage=this.api.defaults.perPage] - Amount of items per page. This is silently capped by the API
    * @param {?Object<String, String|Array<String>>} [params.search] - Search parameters
@@ -130,7 +129,7 @@ export default class SimpleResourceProxy {
    *
    * api.layers.list({perPage: 10, search});
    */
-  list(params) {
+  list(params = {}) {
     const resolver = this._buildResolver(params);
 
     return resolver.getPage(resolver.page);
@@ -138,7 +137,7 @@ export default class SimpleResourceProxy {
 
   /**
    * List target resource
-   * @param {Number|Object} params - ParametersThe page to be requested
+   * @param {Number|Object} [params] - ParametersThe page to be requested
    * @param {Number} [params.page=1] - The page to be requested
    * @param {Number} [params.perPage=this.api.defaults.perPage] - Amount of items per page. This is silently capped by the API
    * @param {Boolean} [params.shareCache=this.api.defaults.shareCache] - Share cache across instances
@@ -154,7 +153,7 @@ export default class SimpleResourceProxy {
    *
    * api.layers.listandWrap({perPage: 10, search});
    */
-  listAndWrap(params) {
+  listAndWrap(params = {}) {
     const resolver = this._buildResolver(params);
     const wrapped = resolver.wrap(resolver.page);
 
@@ -162,7 +161,7 @@ export default class SimpleResourceProxy {
     return wrapped;
   }
 
-  _buildResolver(params) {
+  _buildResolver(params = {}) {
     const paramType = typeof params;
     const url = this._baseUrl;
 


### PR DESCRIPTION
 - Minor cleanups
 - Remove cache time parameter, it's a property now
 - Update some docstrings
 - fix `listWrapper.on` behaviour
 - `ResourceCache::_timestamp` is a getter now
 - Remove `search` and `searchAndWrap` from `SimpleResourceProxy`
 - `SimpleResourceProxy::list*` requires an object containing it's parameters now
